### PR TITLE
Fixed small bug in com.geodesk.core.Box#metersAroundLonLat

### DIFF
--- a/src/main/java/com/geodesk/core/Box.java
+++ b/src/main/java/com/geodesk/core/Box.java
@@ -440,7 +440,7 @@ public class Box implements Bounds
 	 */
 	public static Box metersAroundLonLat(double meters, double lon, double lat)
 	{
-		return metersAroundXY(meters, (int)Mercator.xFromLon(lon), (int)Mercator.yFromLat(lon));
+		return metersAroundXY(meters, (int)Mercator.xFromLon(lon), (int)Mercator.yFromLat(lat));
 	}
 
 	/**


### PR DESCRIPTION
Lon was used twice, to get both x and y, instead of using lat to get y.